### PR TITLE
Disable TouchGoal for FCL 0.6

### DIFF
--- a/bio_ik_service/src/bio_ik_service.cpp
+++ b/bio_ik_service/src/bio_ik_service.cpp
@@ -239,6 +239,10 @@ static void convertGoals(const bio_ik_msgs::IKRequest &ik_request,
     ik_options.goals.emplace_back(new bio_ik::TouchGoal(
         m.link_name, p(m.position), p(m.normal), w(m.weight)));
   }
+#else
+  if (ik_request.touch_goals.size() > 0) {
+    ROS_WARN("TouchGoals are not supported with the current FCL version");
+  }
 #endif
 
   for (auto &m : ik_request.avoid_joint_limits_goals) {

--- a/bio_ik_service/src/bio_ik_service.cpp
+++ b/bio_ik_service/src/bio_ik_service.cpp
@@ -234,10 +234,12 @@ static void convertGoals(const bio_ik_msgs::IKRequest &ik_request,
         m.link_name, p(m.position), p(m.direction), w(m.weight)));
   }
 
+#if (MOVEIT_FCL_VERSION < FCL_VERSION_CHECK(0, 6, 0))
   for (auto &m : ik_request.touch_goals) {
     ik_options.goals.emplace_back(new bio_ik::TouchGoal(
         m.link_name, p(m.position), p(m.normal), w(m.weight)));
   }
+#endif
 
   for (auto &m : ik_request.avoid_joint_limits_goals) {
     ik_options.goals.emplace_back(


### PR DESCRIPTION
The TouchGoal has been deactivated for certain FCL versions in TAMS-Group/bio_ik@cca7aed6745e10f95c55d3da9a67f80cb73cbd45. In this case, it should also be removed here.